### PR TITLE
Update collectd and add facette

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ $(DEBS):
 	$(MAKE) -C debs $(patsubst debs/%, %, $@)
 
 upload: $(OUTPUT)
-	$(foreach package, $(OUTPUT), curl -u "$(ARTIFACTORY_USR):$(ARTIFACTORY_PSW)" -XPUT "http://artifactory.osirium.net/debian-local/pool/$(notdir $(package));deb.distribution=xenial;deb.component=main;deb.architecture=amd64" -T $(package);)
+	$(foreach package, $(OUTPUT), curl -u "$(ARTIFACTORY_USR):$(ARTIFACTORY_PSW)" -XPUT "https://artifactory.osirium.net/artifactory/debian-local/pool/$(notdir $(package));deb.distribution=xenial;deb.component=main;deb.architecture=amd64" -T $(package);)

--- a/debs/collectd/debian/changelog
+++ b/debs/collectd/debian/changelog
@@ -1,3 +1,10 @@
+collectd (5.12.0-ubuntu0) xenial; urgency=medium
+
+  * Bump to 5.12.0
+  * Add postgresql plugin
+
+ -- Osirium <support@osirium.com>  Mon, 23 Nov 2020 14:17:00 +0000
+
 collectd (5.6.2-ubuntu0) xenial; urgency=medium
 
   * Bump to 5.6.2

--- a/debs/collectd/debian/control
+++ b/debs/collectd/debian/control
@@ -2,7 +2,7 @@ Source: collectd
 Section: universe/utils
 Priority: optional
 Maintainer: Osirium <support@osirium.com>
-Build-Depends: debhelper (>= 8.0.0), librrd-dev, rrdtool, python-dev, python
+Build-Depends: debhelper (>= 8.0.0), librrd-dev, libpq-dev, rrdtool, python-dev, python
 Standards-Version: 3.9.4
 Homepage: https://www.osirium.com
 

--- a/debs/facette/.dockerignore
+++ b/debs/facette/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+Dockerfile.tmp

--- a/debs/facette/Dockerfile
+++ b/debs/facette/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:xenial-20171006
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get --quiet --yes --no-install-recommends install \
+      apt-transport-https \
+      build-essential \
+      ca-certificates \
+      curl \
+      debhelper \
+      devscripts \
+      equivs \
+      lsb-release \
+      ;
+
+# We need yarn for which we need apt-transport-https from the previous step
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+RUN apt-get update && apt-get install --quiet --yes yarn nodejs
+
+# Facette needs golang to build
+RUN curl -L "https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz" \
+    | tar -x -v -z -C /usr/local \
+    ;
+
+ENV GOPATH=/root/go
+ENV GOROOT=/usr/local/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+WORKDIR /build/source
+
+COPY debian/changelog debian/changelog
+RUN export VERSION="$( /usr/bin/dpkg-parsechangelog --show-field Version | cut -d'-' -f1 )" \
+    && curl -L "https://github.com/facette/facette/releases/download/${VERSION}/facette_${VERSION}.tar.gz" \
+    | tar -x -v -p -z --strip-components=1
+
+# go-bindata is a pre-req
+# go mod vendor fixes an error about inconsistent vendoring
+RUN go get -u github.com/jteeuwen/go-bindata/... && \
+    go mod vendor \
+    ;
+
+# We override facette's control file to remove the golang-go dependency that can't be met on Xenial
+COPY debian/control debian/control
+
+RUN apt-get update && mk-build-deps --install --tool 'apt-get --no-install-recommends -y'
+
+COPY debian ./debian
+
+# Facette includes a `make dist-deb` rule, but we ignore it in favour of our usual pattern
+# that won't clobber the changelog; or include the package source
+# RUN make dist-deb
+RUN dpkg-buildflags && DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck" dpkg-buildpackage -B
+
+CMD mkdir -p /out/dists/$( lsb_release -c -s )/main/binary-$( dpkg --print-architecture )/ \
+    && dpkg -c /build/*.deb \
+    && cp /build/*.deb /out/dists/$( lsb_release -c -s )/main/binary-$( dpkg --print-architecture )/
+
+
+
+

--- a/debs/facette/debian/changelog
+++ b/debs/facette/debian/changelog
@@ -1,0 +1,5 @@
+facette (0.5.1-ubuntu0) xenial; urgency=low
+
+  * Release 0.5.1
+
+ -- Osirium <support@osirium.com>  Wed, 19 Oct 2016 08:33:00 +0100

--- a/debs/facette/debian/control
+++ b/debs/facette/debian/control
@@ -1,0 +1,21 @@
+Source: facette
+Section: universe/utils
+Priority: optional
+Maintainer: Osirium <support@osirium.com>
+Build-Depends: debhelper (>= 8.0.0),
+  dh-systemd,
+  git,
+  librrd-dev,
+  npm,
+  nodejs-legacy,
+  pandoc,
+  pkg-config,
+  quilt
+Standards-Version: 3.9.4
+Homepage: https://www.osirium.com
+
+Package: facette
+Section: base
+Priority: optional
+Architecture: any
+Description: facette


### PR DESCRIPTION
As part of https://github.com/Osirium/osirium-main/pull/4569 I wanted to use the postgresql plugin. That led me to make this update to collectd.

In order to explore rrd files, I found https://facette.io

However their build of facette for linux required `librrd.so.8` and Xenial only has `librrd.so.4.3.5`. I could have either built a newer librrd for Xenial or built facette against Xenial's librrd. I chose the latter so that the new changes are constrained to facette rather than potentially impacting the already installed `rrdtool`.

Facette is different to most of our third party packages in that it's own repo includes the machinery to build a deb. So we largely rely on that, just tweaking the `changelog` and `control` files to better suit our needs.